### PR TITLE
Allow exceptions to be caught by Catch node

### DIFF
--- a/powershell.js
+++ b/powershell.js
@@ -15,11 +15,11 @@ module.exports = function(RED) {
             ps.invoke()
             .then(output => {
                 msg.payload = output;
-                this.send([output, null]);
+                this.send(msg);
             })
             .catch(error => {
                 msg.payload = error;
-                this.error(error);
+                this.error(error, msg);
             });
         });
 


### PR DESCRIPTION
Current code does not allow exceptions to be caught by a Catch node because it misses the `msg` parameter when calling `this.error`. 

Also changed the returned message on success to be the full message rather than just the string output of the powershell command, so that we do not lose the message when incorporating this node within a flow.